### PR TITLE
deprecated in PHP 7.2 

### DIFF
--- a/Config/Memcache.ini
+++ b/Config/Memcache.ini
@@ -17,9 +17,12 @@ connection_timeout = "3"
 [max_item_dump]
 max_item_dump = "50"
 [server]
-server[] = "localhost:11211"
+server[] = "128.1.230.215:11211"
+server[] = "128.1.230.216:11211"
+server[] = "192.120.1.13:11211"
+server[] = "192.120.1.213:11211"
 [refresh_rate]
-refresh_rate = "2"
+refresh_rate = "60"
 [memory_alert]
 memory_alert = "75"
 [hit_rate_alert]

--- a/Config/Memcache.ini
+++ b/Config/Memcache.ini
@@ -17,12 +17,9 @@ connection_timeout = "3"
 [max_item_dump]
 max_item_dump = "50"
 [server]
-server[] = "128.1.230.215:11211"
-server[] = "128.1.230.216:11211"
-server[] = "192.120.1.13:11211"
-server[] = "192.120.1.213:11211"
+server[] = "localhost:11211"
 [refresh_rate]
-refresh_rate = "60"
+refresh_rate = "5"
 [memory_alert]
 memory_alert = "75"
 [hit_rate_alert]

--- a/Library/Analysis.php
+++ b/Library/Analysis.php
@@ -149,6 +149,10 @@ class Library_Analysis
         $stats['hit_rate'] = number_format(($stats['cmd_set'] + $stats['get_hits'] + $stats['delete_hits'] + $stats['cas_hits'] + $stats['incr_hits'] + $stats['decr_hits']) / $stats['uptime'], 1);
         $stats['miss_rate'] = number_format(($stats['get_misses'] + $stats['delete_misses'] + $stats['cas_misses'] + $stats['cas_badval'] + $stats['incr_misses'] + $stats['decr_misses']) / $stats['uptime'], 1);
 
+        # Eviction & reclaimed rate
+        $stats['eviction_rate'] = ($stats['evictions'] == 0) ? '0.0':number_format($stats['evictions'] / $stats['uptime'], 1);
+        $stats['reclaimed_rate'] = (!isset($stats['reclaimed']) || ($stats['reclaimed'] == 0)) ? '0.0':number_format($stats['reclaimed'] / $stats['uptime'], 1);
+
         return $stats;
     }
 

--- a/Library/Analysis.php
+++ b/Library/Analysis.php
@@ -104,54 +104,54 @@ class Library_Analysis
         }
 
         # Command set()
-        $stats['set_rate'] = ($stats['cmd_set'] == 0) ? '0.0':number_format($stats['cmd_set'] / $stats['uptime'], 1);
+        $stats['set_rate'] = ($stats['cmd_set'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_set'] / $stats['uptime'], 1);
 
         # Command get()
-        $stats['get_hits_percent'] = ($stats['cmd_get'] == 0) ? ' - ':number_format($stats['get_hits'] / $stats['cmd_get'] * 100, 1);
-        $stats['get_misses_percent'] = ($stats['cmd_get'] == 0) ? ' - ':number_format($stats['get_misses'] / $stats['cmd_get'] * 100, 1);
-        $stats['get_rate'] = ($stats['cmd_get'] == 0) ? '0.0':number_format($stats['cmd_get'] / $stats['uptime'], 1);
+        $stats['get_hits_percent'] = ($stats['cmd_get'] == 0) ? ' - ':sprintf('%.1f', $stats['get_hits'] / $stats['cmd_get'] * 100, 1);
+        $stats['get_misses_percent'] = ($stats['cmd_get'] == 0) ? ' - ':sprintf('%.1f', $stats['get_misses'] / $stats['cmd_get'] * 100, 1);
+        $stats['get_rate'] = ($stats['cmd_get'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_get'] / $stats['uptime'], 1);
 
         # Command delete()
         $stats['cmd_delete'] = $stats['delete_hits'] + $stats['delete_misses'];
-        $stats['delete_hits_percent'] = ($stats['cmd_delete'] == 0) ?' - ':number_format($stats['delete_hits'] / $stats['cmd_delete'] * 100, 1);
-        $stats['delete_misses_percent'] = ($stats['cmd_delete'] == 0) ?' - ':number_format($stats['delete_misses'] / $stats['cmd_delete'] * 100, 1);
-        $stats['delete_rate'] = ($stats['cmd_delete'] == 0) ? '0.0':number_format($stats['cmd_delete'] / $stats['uptime'], 1);
+        $stats['delete_hits_percent'] = ($stats['cmd_delete'] == 0) ?' - ':sprintf('%.1f', $stats['delete_hits'] / $stats['cmd_delete'] * 100, 1);
+        $stats['delete_misses_percent'] = ($stats['cmd_delete'] == 0) ?' - ':sprintf('%.1f', $stats['delete_misses'] / $stats['cmd_delete'] * 100, 1);
+        $stats['delete_rate'] = ($stats['cmd_delete'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_delete'] / $stats['uptime'], 1);
 
         # Command cas()
         $stats['cmd_cas'] = $stats['cas_hits'] + $stats['cas_misses'] + $stats['cas_badval'];
-        $stats['cas_hits_percent'] = ($stats['cmd_cas'] == 0) ?' - ':number_format($stats['cas_hits'] / $stats['cmd_cas'] * 100, 1);
-        $stats['cas_misses_percent'] = ($stats['cmd_cas'] == 0) ?' - ':number_format($stats['cas_misses'] / $stats['cmd_cas'] * 100, 1);
-        $stats['cas_badval_percent'] = ($stats['cmd_cas'] == 0) ?' - ':number_format($stats['cas_badval'] / $stats['cmd_cas'] * 100, 1);
-        $stats['cas_rate'] = ($stats['cmd_cas'] == 0) ? '0.0':number_format($stats['cmd_cas'] / $stats['uptime'], 1);
+        $stats['cas_hits_percent'] = ($stats['cmd_cas'] == 0) ?' - ':sprintf('%.1f', $stats['cas_hits'] / $stats['cmd_cas'] * 100, 1);
+        $stats['cas_misses_percent'] = ($stats['cmd_cas'] == 0) ?' - ':sprintf('%.1f', $stats['cas_misses'] / $stats['cmd_cas'] * 100, 1);
+        $stats['cas_badval_percent'] = ($stats['cmd_cas'] == 0) ?' - ':sprintf('%.1f', $stats['cas_badval'] / $stats['cmd_cas'] * 100, 1);
+        $stats['cas_rate'] = ($stats['cmd_cas'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_cas'] / $stats['uptime'], 1);
 
         # Command increment()
         $stats['cmd_incr'] = $stats['incr_hits'] + $stats['incr_misses'];
-        $stats['incr_hits_percent'] = ($stats['cmd_incr'] == 0) ?' - ':number_format($stats['incr_hits'] / $stats['cmd_incr'] * 100, 1);
-        $stats['incr_misses_percent'] = ($stats['cmd_incr'] == 0) ?' - ':number_format($stats['incr_misses'] / $stats['cmd_incr'] * 100, 1);
-        $stats['incr_rate'] = ($stats['cmd_incr'] == 0) ? '0.0':number_format($stats['cmd_incr'] / $stats['uptime'], 1);
+        $stats['incr_hits_percent'] = ($stats['cmd_incr'] == 0) ?' - ':sprintf('%.1f', $stats['incr_hits'] / $stats['cmd_incr'] * 100, 1);
+        $stats['incr_misses_percent'] = ($stats['cmd_incr'] == 0) ?' - ':sprintf('%.1f', $stats['incr_misses'] / $stats['cmd_incr'] * 100, 1);
+        $stats['incr_rate'] = ($stats['cmd_incr'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_incr'] / $stats['uptime'], 1);
 
         # Command decrement()
         $stats['cmd_decr'] = $stats['decr_hits'] + $stats['decr_misses'];
-        $stats['decr_hits_percent'] = ($stats['cmd_decr'] == 0) ?' - ':number_format($stats['decr_hits'] / $stats['cmd_decr'] * 100, 1);
-        $stats['decr_misses_percent'] = ($stats['cmd_decr'] == 0) ?' - ':number_format($stats['decr_misses'] / $stats['cmd_decr'] * 100, 1);
-        $stats['decr_rate'] = ($stats['cmd_decr'] == 0) ? '0.0':number_format($stats['cmd_decr'] / $stats['uptime'], 1);
+        $stats['decr_hits_percent'] = ($stats['cmd_decr'] == 0) ?' - ':sprintf('%.1f', $stats['decr_hits'] / $stats['cmd_decr'] * 100, 1);
+        $stats['decr_misses_percent'] = ($stats['cmd_decr'] == 0) ?' - ':sprintf('%.1f', $stats['decr_misses'] / $stats['cmd_decr'] * 100, 1);
+        $stats['decr_rate'] = ($stats['cmd_decr'] == 0) ? '0.0':sprintf('%.1f', $stats['cmd_decr'] / $stats['uptime'], 1);
 
         # Total hit & miss
         $stats['cmd_total'] = $stats['cmd_get'] + $stats['cmd_set'] + $stats['cmd_delete'] + $stats['cmd_cas'] + $stats['cmd_incr'] + $stats['cmd_decr'];
-        $stats['hit_percent'] = ($stats['cmd_total'] == 0) ? '0.0':number_format(($stats['cmd_set'] + $stats['get_hits'] + $stats['delete_hits'] + $stats['cas_hits'] + $stats['incr_hits'] + $stats['decr_hits']) / $stats['cmd_total'] * 100, 1);
-        $stats['miss_percent'] = ($stats['cmd_total'] == 0) ? '0.0':number_format(($stats['get_misses'] + $stats['delete_misses'] + $stats['cas_misses'] + $stats['cas_badval'] + $stats['incr_misses'] + $stats['decr_misses']) / $stats['cmd_total'] * 100, 1);
+        $stats['hit_percent'] = ($stats['cmd_total'] == 0) ? '0.0':sprintf('%.1f', ($stats['cmd_set'] + $stats['get_hits'] + $stats['delete_hits'] + $stats['cas_hits'] + $stats['incr_hits'] + $stats['decr_hits']) / $stats['cmd_total'] * 100, 1);
+        $stats['miss_percent'] = ($stats['cmd_total'] == 0) ? '0.0':sprintf('%.1f', ($stats['get_misses'] + $stats['delete_misses'] + $stats['cas_misses'] + $stats['cas_badval'] + $stats['incr_misses'] + $stats['decr_misses']) / $stats['cmd_total'] * 100, 1);
 
         # Cache size
-        $stats['bytes_percent'] = ($stats['limit_maxbytes'] == 0) ? '0.0' : number_format($stats['bytes'] / $stats['limit_maxbytes'] * 100, 1);
+        $stats['bytes_percent'] = ($stats['limit_maxbytes'] == 0) ? '0.0' : sprintf('%.1f', $stats['bytes'] / $stats['limit_maxbytes'] * 100, 1);
 
         # Request rate
-        $stats['request_rate'] = number_format(($stats['cmd_get'] + $stats['cmd_set'] + $stats['cmd_delete'] + $stats['cmd_cas'] + $stats['cmd_incr'] + $stats['cmd_decr']) / $stats['uptime'], 1);
-        $stats['hit_rate'] = number_format(($stats['cmd_set'] + $stats['get_hits'] + $stats['delete_hits'] + $stats['cas_hits'] + $stats['incr_hits'] + $stats['decr_hits']) / $stats['uptime'], 1);
-        $stats['miss_rate'] = number_format(($stats['get_misses'] + $stats['delete_misses'] + $stats['cas_misses'] + $stats['cas_badval'] + $stats['incr_misses'] + $stats['decr_misses']) / $stats['uptime'], 1);
+        $stats['request_rate'] = sprintf('%.1f', ($stats['cmd_get'] + $stats['cmd_set'] + $stats['cmd_delete'] + $stats['cmd_cas'] + $stats['cmd_incr'] + $stats['cmd_decr']) / $stats['uptime'], 1);
+        $stats['hit_rate'] = sprintf('%.1f', ($stats['cmd_set'] + $stats['get_hits'] + $stats['delete_hits'] + $stats['cas_hits'] + $stats['incr_hits'] + $stats['decr_hits']) / $stats['uptime'], 1);
+        $stats['miss_rate'] = sprintf('%.1f', ($stats['get_misses'] + $stats['delete_misses'] + $stats['cas_misses'] + $stats['cas_badval'] + $stats['incr_misses'] + $stats['decr_misses']) / $stats['uptime'], 1);
 
         # Eviction & reclaimed rate
-        $stats['eviction_rate'] = ($stats['evictions'] == 0) ? '0.0':number_format($stats['evictions'] / $stats['uptime'], 1);
-        $stats['reclaimed_rate'] = (!isset($stats['reclaimed']) || ($stats['reclaimed'] == 0)) ? '0.0':number_format($stats['reclaimed'] / $stats['uptime'], 1);
+        $stats['eviction_rate'] = ($stats['evictions'] == 0) ? '0.0':sprintf('%.1f', $stats['evictions'] / $stats['uptime'], 1);
+        $stats['reclaimed_rate'] = (!isset($stats['reclaimed']) || ($stats['reclaimed'] == 0)) ? '0.0':sprintf('%.1f', $stats['reclaimed'] / $stats['uptime'], 1);
 
         return $stats;
     }
@@ -179,7 +179,7 @@ class Library_Analysis
                 {
                     $slabs['used_slabs']++;
                 }
-                $slabs[$id]['request_rate'] = number_format(($slab['get_hits'] + $slab['cmd_set'] + $slab['delete_hits'] + $slab['cas_hits'] + $slab['cas_badval'] + $slab['incr_hits'] + $slab['decr_hits']) / $slabs['uptime'], 1);
+                $slabs[$id]['request_rate'] = sprintf('%.1f', ($slab['get_hits'] + $slab['cmd_set'] + $slab['delete_hits'] + $slab['cas_hits'] + $slab['cas_badval'] + $slab['incr_hits'] + $slab['decr_hits']) / $slabs['uptime'], 1);
                 $slabs[$id]['mem_wasted'] = (($slab['total_chunks'] * $slab['chunk_size']) < $slab['mem_requested']) ?(($slab['total_chunks'] -  $slab['used_chunks']) * $slab['chunk_size']):(($slab['total_chunks'] * $slab['chunk_size']) - $slab['mem_requested']);
                 $slabs['total_wasted'] += $slabs[$id]['mem_wasted'];
             }

--- a/Library/Command/Factory.php
+++ b/Library/Command/Factory.php
@@ -37,7 +37,7 @@ class Library_Command_Factory
         $_ini = Library_Configuration::getInstance();
 
         # Instance does not exists
-        if(!isset(self::$_object[$_ini->get($command)]) || ($_ini->get($command) == 'Memcache'))
+        if(!isset(self::$_object[$_ini->get($command)]) || ($_ini->get($command) != 'Server'))
         {
             # Switching by API
             switch($_ini->get($command))
@@ -75,7 +75,7 @@ class Library_Command_Factory
     public static function api($api)
     {
         # Instance does not exists
-        if(!isset(self::$_object[$api]) || ($api == 'Memcache'))
+        if(!isset(self::$_object[$api]) || ($api != 'Server'))
         {
             # Switching by API
             switch($api)

--- a/Library/Command/Factory.php
+++ b/Library/Command/Factory.php
@@ -37,7 +37,7 @@ class Library_Command_Factory
         $_ini = Library_Configuration::getInstance();
 
         # Instance does not exists
-        if(!isset(self::$_object[$_ini->get($command)]))
+        if(!isset(self::$_object[$_ini->get($command)]) || ($_ini->get($command) == 'Memcache'))
         {
             # Switching by API
             switch($_ini->get($command))
@@ -75,7 +75,7 @@ class Library_Command_Factory
     public static function api($api)
     {
         # Instance does not exists
-        if(!isset(self::$_object[$api]))
+        if(!isset(self::$_object[$api]) || ($api == 'Memcache'))
         {
             # Switching by API
             switch($api)

--- a/Public/Scripts/Script.js
+++ b/Public/Scripts/Script.js
@@ -1,6 +1,7 @@
 function changeServer(obj){if(obj.options[obj.selectedIndex].value!=''){window.location='index.php?server='+obj.options[obj.selectedIndex].value;}else{window.location='index.php';}}
 function serverOnFocus(obj){if(obj.value=='hostname:port'){obj.value='';}}
 function serverOnBlur(obj){if(obj.value==''){obj.value='hostname:port';}}
+function flushServer(obj){if(confirm('Are you sure you want to execute flush_all on server')==true){obj.submit();}return false;}
 var server=0;function addServer(){var serverDiv=document.createElement('div');var serverID=server++;serverDiv.innerHTML='<div class="row"><div class="left">Server</div>'
 +'<div><input type="text" name="server[]" value="hostname:port" onfocus="serverOnFocus(this)" onblur="serverOnBlur(this)">'
 +' <a class="menu grey serverlist" style="padding:1px 2px;-moz-border-radius:3px;-webkit-border-radius:3px;" href="#" onclick="deleteServer(\'server_'

--- a/Public/Styles/Style.css
+++ b/Public/Styles/Style.css
@@ -8,7 +8,6 @@ input,select,textarea{border:solid 1px #AAAAAA;-moz-border-radius:3px;-webkit-bo
 input:focus,textarea:focus{border:solid 1px #EEEEEE;}
 input:hover{color:#AA0000;}
 select{width:201px;}
-tr.title{color:FFFFFF;width:772px;padding:3px 7px 3px 7px;background:#514845;font-weight:bold;}
 div.title{display:block;width:772px;padding:3px 7px 3px 7px;background:#514845;font-weight:bold;}
 span.title{display:block;width:241px;padding:3px 7px 3px 7px;background:#514845;font-weight:bold;}
 .container{width:254px;background:#DBDBDB;margin-top:1px;padding-bottom:3px;}

--- a/View/Commands/Commands.tpl
+++ b/View/Commands/Commands.tpl
@@ -100,7 +100,7 @@
         <br/>
         <span class="title grey rounded" style="width:374px;">Flush Server <span class="green">Command</span></span>
         <div class="container rounded" style="width:374px;padding:7px;">
-            <form method="post" action="commands.php">
+            <form method="post" id="flushForm" action="commands.php">
                 <div class="row">
                     Execute flush_all command on one or all memcached servers<br/>
                     Delay in second before flushing is optional<br/>
@@ -121,7 +121,7 @@
                 <div class="row" style="text-align:center;">
                     <hr/>
                     <input type="hidden" name="request_command" value="flush_all"/>
-                    <input class="menu serverlist" type="submit" value="Execute Flush All"/>
+                    <input class="menu serverlist" type="submit" onclick="return flushServer(document.getElementById('flushForm'))" value="Execute Flush All"/>
                 </div>
             </form>
         </div>

--- a/View/Header.tpl
+++ b/View/Header.tpl
@@ -9,7 +9,7 @@
 <div style="margin: 0 auto;width:800px;">
     <div style="margin: 0 auto;width:788px;clear:both;float:left;">
 
-        <div style="margin:-4px 0px 6px 6px;font-weight:bold;font-size:1.2em;">phpMemCacheAdmin <sup>1.1.2</sup></div>
+        <div style="margin:-4px 0px 6px 6px;font-weight:bold;font-size:1.2em;">phpMemCacheAdmin <sup>1.1.3</sup></div>
         <div class="serverlist rounded" style="padding:3px 7px 3px 7px;width:772px;">
 <?php
 # Live Stats view

--- a/View/Header.tpl
+++ b/View/Header.tpl
@@ -9,7 +9,7 @@
 <div style="margin: 0 auto;width:800px;">
     <div style="margin: 0 auto;width:788px;clear:both;float:left;">
 
-        <div style="margin:-4px 0px 6px 6px;font-weight:bold;font-size:1.2em;">phpMemCacheAdmin</div>
+        <div style="margin:-4px 0px 6px 6px;font-weight:bold;font-size:1.2em;">phpMemCacheAdmin <sup>1.1.2</sup></div>
         <div class="serverlist rounded" style="padding:3px 7px 3px 7px;width:772px;">
 <?php
 # Live Stats view

--- a/View/LiveStats/Frame.tpl
+++ b/View/LiveStats/Frame.tpl
@@ -1,6 +1,5 @@
 <br/>
 <script type="text/javascript">
-var initTimeout = 5000;
 var timeout = <?php echo $_ini->get('refresh_rate') * 1000; ?>;
 setTimeout("ajax(page,'stats')", 5000);
 </script>

--- a/View/LiveStats/Frame.tpl
+++ b/View/LiveStats/Frame.tpl
@@ -1,7 +1,8 @@
 <br/>
 <script type="text/javascript">
+var initTimeout = 5000;
 var timeout = <?php echo $_ini->get('refresh_rate') * 1000; ?>;
-setTimeout("ajax(page,'stats')", timeout);
+setTimeout("ajax(page,'stats')", 5000);
 </script>
 
 <div style="float: left;">
@@ -9,6 +10,6 @@ setTimeout("ajax(page,'stats')", timeout);
     <div style="width:772px;padding-left:4px;">
         <br/>
         <pre id="stats" style="font-size:12px;overflow:visible;">
-        Loading live stats, please wait ...</pre>
+        Loading live stats, please wait 5 seconds ...</pre>
     </div>
 </div>

--- a/View/LiveStats/Stats.tpl
+++ b/View/LiveStats/Stats.tpl
@@ -53,13 +53,13 @@ foreach($stats as $server => $data)
     # Delete rate
     echo sprintf('%8s', Library_Analysis::valueResize($data['delete_rate']));
     # Eviction rate
-    if($data['evictions'] > $_ini->get('eviction_alert'))
+    if($data['eviction_rate'] > $_ini->get('eviction_alert'))
     {
-        echo str_pad('', 9 - strlen(Library_Analysis::valueResize($data['evictions'])), ' ') . '<span class="alert">' . Library_Analysis::valueResize($data['evictions']) . '</span>';
+        echo str_pad('', 9 - strlen(Library_Analysis::valueResize($data['eviction_rate'])), ' ') . '<span class="alert">' . Library_Analysis::valueResize($data['eviction_rate']) . '</span>';
     }
     else
     {
-        echo sprintf('%9s', Library_Analysis::valueResize($data['evictions']));
+        echo sprintf('%9s', Library_Analysis::valueResize($data['eviction_rate']));
     }
     # Bytes read
     echo sprintf('%10s', Library_Analysis::byteResize($data['bytes_read'] / $data['time']) . 'b');

--- a/View/Stats/Slabs.tpl
+++ b/View/Stats/Slabs.tpl
@@ -59,9 +59,6 @@ foreach($slabs as $id => $slab)
 <?php
             $actualSlab = 0;
         }
-        # Making a new cell
-        else
-        {
 ?>
         <td <?php if($actualSlab > 0) { echo 'style="padding-left:10px;"'; } ?>>
             <br/>
@@ -114,7 +111,6 @@ foreach($slabs as $id => $slab)
             </td>
 <?php
             $actualSlab++;
-        }
     }
 ?>
 <?php

--- a/View/Stats/Slabs.tpl
+++ b/View/Stats/Slabs.tpl
@@ -22,13 +22,13 @@
 
     </div>
     <div style="float:left; padding-left:10px;">
-        <form method="get" id="flushForm" action="commands.php">
+        <form method="post" id="flushForm" action="commands.php">
         <div class="serverlist rounded" style="padding: 5px 12px 4px 32px;height:18px;margin:0px;width:211px;">
             <a href="?server=<?php echo $_GET['server']; ?>">See Stats</a> |
             <input type="hidden" name="request_server" value="<?php echo $_GET['server']; ?>"/>
             <input type="hidden" name="request_api" value="<?php echo $_ini->get('flush_all_api'); ?>"/>
             <input type="hidden" name="request_command" value="flush_all"/>
-            <a href="#" onclick="document.getElementById('flushForm').submit();">Flush this Server</a>
+            <a href="#" onclick="flushServer(document.getElementById('flushForm'));">Flush this Server</a>
         </div>
         </form>
         <div class="container rounded" style="width:506px;padding:7px;margin-top:34px;">

--- a/View/Stats/Stats.tpl
+++ b/View/Stats/Stats.tpl
@@ -167,8 +167,12 @@ if(isset($_GET['server']))
                 <div class="full"><?php echo Library_Analysis::hitResize($stats['total_items']); ?></div>
             </div>
             <div class="row">
-                <div class="left">Garbage Items</div>
+                <div class="left">Items Eviction</div>
                 <div class="full"><?php echo Library_Analysis::hitResize($stats['evictions']); ?></div>
+            </div>
+            <div class="row">
+                <div class="left">Eviction Rate</div>
+                <div class="full"><?php echo $stats['eviction_rate']; ?> Request/sec</div>
             </div>
         </div>
         <br/>

--- a/View/Stats/Stats.tpl
+++ b/View/Stats/Stats.tpl
@@ -124,7 +124,7 @@ if(isset($_GET['server']))
             <input type="hidden" name="request_server" value="<?php echo $_GET['server']; ?>"/>
             <input type="hidden" name="request_api" value="<?php echo $_ini->get('flush_all_api'); ?>"/>
             <input type="hidden" name="request_command" value="flush_all"/>
-            <a href="#" onclick="document.getElementById('flushForm').submit();">Flush this Server</a>
+            <a href="#" onclick="flushServer(document.getElementById('flushForm'));">Flush this Server</a>
         </div>
         </form>
         <br/>
@@ -166,14 +166,32 @@ if(isset($_GET['server']))
                 <div class="left">Total Items</div>
                 <div class="full"><?php echo Library_Analysis::hitResize($stats['total_items']); ?></div>
             </div>
+        </div>
+        <br/>
+        <span class="title grey rounded">Eviction <?php if(isset($stats['reclaimed'])) { echo ' &amp; Reclaimed'; } ?> <span class="green">Stats</span></span>
+        <div class="container rounded">
             <div class="row">
                 <div class="left">Items Eviction</div>
                 <div class="full"><?php echo Library_Analysis::hitResize($stats['evictions']); ?></div>
             </div>
             <div class="row">
-                <div class="left">Eviction Rate</div>
-                <div class="full"><?php echo $stats['eviction_rate']; ?> Request/sec</div>
+                <div class="left">Rate</div>
+                <div class="full"><?php echo $stats['eviction_rate']; ?> Eviction/sec</div>
             </div>
+<?php
+# Memcached version 1.4.5 and above
+if(isset($stats['reclaimed']))
+{ ?>
+            <div class="row">
+                <div class="left">Reclaimed</div>
+                <div class="full"><?php echo Library_Analysis::hitResize($stats['reclaimed']); ?></div>
+            </div>
+            <div class="row">
+                <div class="left">Rate</div>
+                <div class="full"><?php echo $stats['reclaimed_rate']; ?> Reclaimed/sec</div>
+            </div>
+<?php
+} ?>
         </div>
         <br/>
 

--- a/stats.php
+++ b/stats.php
@@ -89,6 +89,7 @@ switch($request)
             # Making stats for each server
             foreach($stats as $server => $array)
             {
+                if($stats[$server]['uptime'] == 0) { $stats[$server]['uptime'] = $_ini->get('refresh_rate'); }
                 $stats[$server] = Library_Analysis::stats($stats[$server]);
                 $stats[$server]['bytes_percent'] = number_format($new_stats[$server]['bytes'] / $new_stats[$server]['limit_maxbytes'] * 100, 1);
                 $stats[$server]['curr_connections'] = $new_stats[$server]['curr_connections'];


### PR DESCRIPTION
Hi,
__autoload had been deprecated in php7.2
You could simply change it with spl_autoload_register in /Library/Loader.php : 
# Autoloader
spl_autoload_register(function ($class)
{
    require_once str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
});
Regards,

